### PR TITLE
[Issue 2]: Added CORS headers arguments to Dockerfile and Dockerfile template

### DIFF
--- a/swagger-notebook-service/README.md
+++ b/swagger-notebook-service/README.md
@@ -17,3 +17,12 @@ cd swagger-petstore-service
 # run the docker container
 ./run.sh
 ```
+
+This service can be accessed from the [swagger editor](http://editor.swagger.io).
+To get the editor to correctly interact with the API:
+* Copy the contents of `SwaggerPetstoreSpec.yaml`
+```
+cat swagger-petstore-service/SwaggerPetstoreSpec.yaml | pbcopy
+```
+* Go to http://editor.swagger.io and paste the contents into the editor
+* Modify the `host` property in the document to point to the `ip:port` of your docker container

--- a/swagger-notebook-service/jupyter-swagger-codegen/src/main/resources/jupyter-swagger-codegen/Dockerfile.mustache
+++ b/swagger-notebook-service/jupyter-swagger-codegen/src/main/resources/jupyter-swagger-codegen/Dockerfile.mustache
@@ -14,8 +14,10 @@ LABEL service="{{appName}}"
 CMD [ \
         "--KernelGatewayApp.api=notebook-http", \
         "--KernelGatewayApp.seed_uri=/srv/notebooks/{{notebookFile}}", \
+        "--KernelGatewayApp.allow_origin='http://editor.swagger.io'", \
+        " --KernelGatewayApp.allow_methods='GET, POST, PUT, DELETE'", \
+        "--KernelGatewayApp.allow_headers='accept, accept-language, content-type'", \
         "--KernelGatewayApp.ip=0.0.0.0" \
     ]
 
 ADD {{notebookFile}} /srv/notebooks/
-

--- a/swagger-notebook-service/swagger-petstore-service/Dockerfile
+++ b/swagger-notebook-service/swagger-petstore-service/Dockerfile
@@ -14,6 +14,9 @@ LABEL service="Swagger Petstore"
 CMD [ \
         "--KernelGatewayApp.api=notebook-http", \
         "--KernelGatewayApp.seed_uri=/srv/notebooks/SwaggerPetstoreApi.ipynb", \
+        "--KernelGatewayApp.allow_origin='http://editor.swagger.io'", \
+        " --KernelGatewayApp.allow_methods='GET, POST, PUT, DELETE'", \
+        "--KernelGatewayApp.allow_headers='accept, accept-language, content-type'", \
         "--KernelGatewayApp.ip=0.0.0.0" \
     ]
 

--- a/swagger-notebook-service/swagger-petstore-service/package.sh
+++ b/swagger-notebook-service/swagger-petstore-service/package.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-docker build -t swagger-petstore:1.0.0 .
+docker build --no-cache -t  swagger-petstore:1.0.0 .


### PR DESCRIPTION
Will add the ability for requests to come from http://editor.swagger.io. Includes documentation to get the container service talking with the swagger editor
