### PR TITLE
More feature-filled nodejs client example

### DIFF
--- a/node_client_example/.gitignore
+++ b/node_client_example/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/node_client_example/Dockerfile.kg
+++ b/node_client_example/Dockerfile.kg
@@ -1,0 +1,9 @@
+# start from the jupyter image with R, Python, and Scala (Apache Toree) kernels pre-installed
+FROM jupyter/all-spark-notebook:0017b56d93c9
+
+# install the kernel gateway
+RUN pip install 'jupyter_kernel_gateway==0.5'
+
+# run kernel gateway on container start, not notebook server
+EXPOSE 8888
+CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0", "--KernelGatewayApp.port=8888"]

--- a/node_client_example/Dockerfile.kg
+++ b/node_client_example/Dockerfile.kg
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 # start from the jupyter image with R, Python, and Scala (Apache Toree) kernels pre-installed
 FROM jupyter/all-spark-notebook:0017b56d93c9
 

--- a/node_client_example/Dockerfile.nginx
+++ b/node_client_example/Dockerfile.nginx
@@ -1,2 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 FROM nginx:1.7.6
 ADD nginx.conf /etc/nginx/nginx.conf

--- a/node_client_example/Dockerfile.nginx
+++ b/node_client_example/Dockerfile.nginx
@@ -1,0 +1,2 @@
+FROM nginx:1.7.6
+ADD nginx.conf /etc/nginx/nginx.conf

--- a/node_client_example/README.md
+++ b/node_client_example/README.md
@@ -1,41 +1,17 @@
-## NodeJS Client Example
+# Example: NodeJS Client
 
-The following sample uses the new `jupyter-js-services` npm package to request a kernel from a kernel gateway and execute some code on it. You can find this sample in `etc/node_client_example` in this repo along with a `package.json` file that installs all the client dependencies (i.e., run `npm install` then `node client.js`).
+Demonstrates a simple NodeJS client using jupyter-js-services sending Python or Scala code to a kernel gateway, through an nginx proxy. The Python / Scala code examples use the Spark API.
 
-```javascript
-var xmlhttprequest = require('xmlhttprequest');
-var ws = require('ws');
+```
+# in one terminal
+git clone https://github.com/jupyter/kernel_gateway_demos
+cd kernel_gateway_demos/node_client_example
+docker-compose build
+docker-compose up
 
-global.XMLHttpRequest = xmlhttprequest.XMLHttpRequest;
-global.WebSocket = ws;
-
-var jupyter = require('jupyter-js-services');
-
-var kg_host = process.env.GATEWAY_HOST || '192.168.99.100:8888';
-
-// get info about the available kernels and start a new one
-jupyter.getKernelSpecs('http://'+kg_host).then((kernelSpecs) => {
-    console.log('Available kernelspecs:', kernelSpecs);
-    var options = {
-        baseUrl: 'http://'+kg_host,
-        wsUrl: 'ws://'+kg_host,
-        name: kernelSpecs.default
-    };
-    // request a kernel in the default language (python)
-    jupyter.startNewKernel(options).then((kernel) => {
-        // execute some code
-        var future = kernel.execute({ code: 'print("Hello world!")' } );
-        future.onDone = () => {
-            // quit when done
-            process.exit(0);
-        };
-        future.onIOPub = (msg) => {
-            // print received messages
-            console.log('Received message type:', msg.msg_type);
-            if(msg.msg_type === 'stream') {
-                console.log('  Content:', msg.content.text);
-            }
-        };
-    });
-});
+# in another
+cd kernel_gateway_demos/node_client_example
+npm install
+export GATEWAY_HOST=<ip of your docker host>:8080 
+DEMO_LANG=<python|scala> node client.js
 ```

--- a/node_client_example/client.js
+++ b/node_client_example/client.js
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 var xmlhttprequest = require('xmlhttprequest');
 var ws = require('ws');
 var fs = require('fs');

--- a/node_client_example/client.js
+++ b/node_client_example/client.js
@@ -1,15 +1,21 @@
-// Copyright (c) Jupyter Development Team.
-// Distributed under the terms of the Modified BSD License.
-
 var xmlhttprequest = require('xmlhttprequest');
 var ws = require('ws');
+var fs = require('fs');
 
 global.XMLHttpRequest = xmlhttprequest.XMLHttpRequest;
 global.WebSocket = ws;
 
+var PYTHON_EXAMPLE = fs.readFileSync('example.py', {encoding: 'utf-8'});
+var SCALA_EXAMPLE = fs.readFileSync('example.scala', {encoding: 'utf-8'});
+
 var jupyter = require('jupyter-js-services');
 
 var kg_host = process.env.GATEWAY_HOST || '192.168.99.100:8888';
+var demo_lang = process.env.DEMO_LANG === 'scala' ? 'scala' : 'python';
+var demo_code = (demo_lang === 'scala') ? SCALA_EXAMPLE : PYTHON_EXAMPLE;
+
+console.log('Targeting server:', kg_host);
+console.log('Using demo lang:', demo_lang);
 
 // get info about the available kernels and start a new one
 jupyter.getKernelSpecs('http://'+kg_host).then((kernelSpecs) => {
@@ -17,22 +23,21 @@ jupyter.getKernelSpecs('http://'+kg_host).then((kernelSpecs) => {
     var options = {
         baseUrl: 'http://'+kg_host,
         wsUrl: 'ws://'+kg_host,
-        name: kernelSpecs.default
+        name: demo_lang
     };
     // request a kernel in the default language (python)
+    console.log('Starting kernel:', demo_lang)
     jupyter.startNewKernel(options).then((kernel) => {
         // execute some code
-        var future = kernel.execute({ code: 'print("Hello world!")' } );
+        console.log('Executing sample code');
+        var future = kernel.execute({ code: demo_code  } );
         future.onDone = () => {
             // quit when done
             process.exit(0);
         };
         future.onIOPub = (msg) => {
             // print received messages
-            console.log('Received message type:', msg.msg_type);
-            if(msg.msg_type === 'stream') {
-                console.log('  Content:', msg.content.text);
-            }
+            console.log('Received message:', msg);
         };
     });
 });

--- a/node_client_example/docker-compose.yml
+++ b/node_client_example/docker-compose.yml
@@ -1,3 +1,7 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+---
+
 version: "2"
 
 services:

--- a/node_client_example/docker-compose.yml
+++ b/node_client_example/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "2"
+
+services:
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    image: jupyter/kernel-gateway-nginx
+    ports:
+      - "8080:80"
+    depends_on:
+      - kernel_gateway
+    links:
+      - kernel_gateway
+
+  kernel_gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.kg
+    image: jupyter/kernel-gateway
+    environment:
+      KG_ALLOW_ORIGIN: '*'

--- a/node_client_example/example.py
+++ b/node_client_example/example.py
@@ -1,3 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 import pyspark
 sc = pyspark.SparkContext()
 rdd = sc.parallelize(range(1000))

--- a/node_client_example/example.py
+++ b/node_client_example/example.py
@@ -1,0 +1,5 @@
+import pyspark
+sc = pyspark.SparkContext()
+rdd = sc.parallelize(range(1000))
+sample = rdd.takeSample(False, 5)
+print(sample)

--- a/node_client_example/example.scala
+++ b/node_client_example/example.scala
@@ -1,0 +1,19 @@
+import org.apache.spark.sql.SQLContext
+
+case class custTab(col0: Integer, col1: String, col2: String, col3: String)
+
+// explicitly create a sqlcontext
+val sqlC = new SQLContext(sc)
+
+// to get the toDF method
+import sqlC.implicits._
+
+val custDataTs = Seq(
+     custTab(1, "14/Jul/2012:15:58:12 +0000", "ABC", "Error in transaction processing"),
+     custTab(2, "10/14/12 03:34:39", "OR", "Warning systems down"),
+     custTab(3, "NA", "DEF", "Normal"),
+     custTab(4, "2014.06.09 06:30PM", "CA", "Emergency shutdown alert"),
+     custTab(5, "None", "MA", "")
+   )
+val custTableTs = sc.parallelize(custDataTs, 4).toDF()
+custTableTs.show()

--- a/node_client_example/example.scala
+++ b/node_client_example/example.scala
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 import org.apache.spark.sql.SQLContext
 
 case class custTab(col0: Integer, col1: String, col2: String, col3: String)

--- a/node_client_example/nginx.conf
+++ b/node_client_example/nginx.conf
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 user nginx;
 worker_processes 1;
 

--- a/node_client_example/nginx.conf
+++ b/node_client_example/nginx.conf
@@ -1,0 +1,39 @@
+user nginx;
+worker_processes 1;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+
+  upstream kernel_gateway {
+    server kernel_gateway:8888;
+  }
+
+  proxy_http_version 1.1;
+  client_max_body_size            0;
+  chunked_transfer_encoding       on;
+
+  server {
+    listen                          80;
+    server_name                     kernel_gateway;
+
+    location / {
+      proxy_pass http://kernel_gateway;
+
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Scheme https;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-NginX-Proxy true;
+
+      # WebSocket support
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_read_timeout 86400;
+    }
+  }
+}


### PR DESCRIPTION
Move https://gist.github.com/parente/2d3ff03a2e4e1b0aa1c0 to here to become the nodejs example. Includes:
- jupyter-js-services 0.8
- nginx proxy
- docker-compose recipe
- easily replaceable python/scala snippets (defaults use spark)
