### PR TITLE
Clean up the node demo

### DIFF
--- a/node_client_example/client.js
+++ b/node_client_example/client.js
@@ -14,6 +14,7 @@ var SCALA_EXAMPLE = fs.readFileSync('example.scala', {encoding: 'utf-8'});
 var jupyter = require('jupyter-js-services');
 
 var kg_host = process.env.GATEWAY_HOST || '192.168.99.100:8888';
+var baseUrl = 'http://' + kg_host;
 var demo_lang = process.env.DEMO_LANG === 'scala' ? 'scala' : 'python';
 var demo_code = (demo_lang === 'scala') ? SCALA_EXAMPLE : PYTHON_EXAMPLE;
 
@@ -21,11 +22,10 @@ console.log('Targeting server:', kg_host);
 console.log('Using demo lang:', demo_lang);
 
 // get info about the available kernels and start a new one
-jupyter.getKernelSpecs('http://'+kg_host).then((kernelSpecs) => {
+jupyter.getKernelSpecs({ baseUrl:  baseUrl}).then((kernelSpecs) => {
     console.log('Available kernelspecs:', kernelSpecs);
     var options = {
-        baseUrl: 'http://'+kg_host,
-        wsUrl: 'ws://'+kg_host,
+        baseUrl: baseUrl,
         name: demo_lang
     };
     // request a kernel in the default language (python)


### PR DESCRIPTION
@parente, even with these changes, I see the following problem:

<img width="480" alt="screen shot 2016-04-18 at 1 41 01 pm" src="https://cloud.githubusercontent.com/assets/2096628/14615440/473a13ae-056b-11e6-9328-e47d7e0b4a06.png">

``` bash
$ docker-compose up
Starting nodeclientexample_kernel_gateway_1
Starting nodeclientexample_nginx_1
Attaching to nodeclientexample_kernel_gateway_1, nodeclientexample_nginx_1
kernel_gateway_1 | [KernelGatewayApp] The Jupyter Kernel Gateway is running at: http://0.0.0.0:8888
```

``` bash
ssilvester: ~/workspace/jupyter/kernel_gateway_demos/node_client_example (update-node-demo-again) 0
$ export GATEWAY_HOST=0.0.0.0:8888

ssilvester: ~/workspace/jupyter/kernel_gateway_demos/node_client_example (update-node-demo-again) 0
$ DEMO_LANG=python node-debug client.js
Node Inspector is now available from http://127.0.0.1:8080/?ws=127.0.0.1:8080&port=5858
Debugging `client.js`

Debugger listening on port 5858
```

``` bash
ssilvester: ~/workspace/jupyter/kernel_gateway_demos/node_client_example (update-node-demo-again) 0
$ DEMO_LANG=python node client.js
Targeting server: 0.0.0.0:8888
Using demo lang: python

ssilvester: ~/workspace/jupyter/kernel_gateway_demos/node_client_example (update-node-demo-again) 0
$
```
