### PR TITLE
Show basic auth in examples

### DIFF
--- a/node_client_example/Dockerfile.kg
+++ b/node_client_example/Dockerfile.kg
@@ -5,7 +5,7 @@
 FROM jupyter/all-spark-notebook:0017b56d93c9
 
 # install the kernel gateway
-RUN pip install 'jupyter_kernel_gateway==0.5'
+RUN pip install jupyter_kernel_gateway==0.5.*
 
 # run kernel gateway on container start, not notebook server
 EXPOSE 8888

--- a/node_client_example/Dockerfile.nginx
+++ b/node_client_example/Dockerfile.nginx
@@ -3,3 +3,4 @@
 
 FROM nginx:1.7.6
 ADD nginx.conf /etc/nginx/nginx.conf
+ADD fake_htpasswd /etc/nginx/htpasswd

--- a/node_client_example/README.md
+++ b/node_client_example/README.md
@@ -1,6 +1,8 @@
 # Example: NodeJS Client
 
-Demonstrates a simple NodeJS client using jupyter-js-services sending Python or Scala code to a kernel gateway, through an nginx proxy. The code examples use the Spark API. The proxy only exists to show that the kernel gateway can run behind a common proxy.
+Demonstrates a NodeJS client using jupyter-js-services sending Python or Scala code to a kernel gateway, through an nginx proxy, with basic auth configured. The code examples use the Spark API. 
+
+**Note** that nginx only exists here to show that the kernel gateway can run behind a common proxy. (You can connect the client directly to the kernel gateway of course!)
 
 ```
 git clone https://github.com/jupyter/kernel_gateway_demos
@@ -9,17 +11,10 @@ docker-compose build
 docker-compose up
 ```
 
-When you run docker-compose up the first time, it will launch an nginx proxy, a kernel gateway, and the client running the `src/example.py` with all logs aggregated. Once the client completes, it will exist. If you want to run the client again without restarting the other two services, do this in another terminal:
+When you run docker-compose up the first time, it will launch an nginx proxy, a kernel gateway, and the client  with all logs aggregated. The client will send the `src/example.py` code to the kernel gateway for execution. Once the client completes, it will exit. If you want to run the client again without restarting the other two services, do this in another terminal:
 
 ```
 docker-compose run -e DEMO_LANG=<scala|python|r> client
 ```
 
-You can also run the node client right on your host if you configure it to point to the proxy like so:
-
-```
-cd kernel_gateway_demos/node_client_example
-npm install
-export GATEWAY_HOST=<ip of your docker host>:8080 
-DEMO_LANG=<python|scala|r> node client.js
-```
+You can also run the `src/client.js` on your host without Docker if you `npm install` its dependencies and configure it with the proper environment variables. See what the `docker-compose.yml` and `Dockerfile.client` do as a reference.

--- a/node_client_example/docker-compose.yml
+++ b/node_client_example/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: Dockerfile.nginx
     image: jupyter/kernel-gateway-nginx
     ports:
-      - "8080:80"
+      - "8080:80" # for testing proxied access to the kernel gateway from outside docker
     depends_on:
       - kernel_gateway
 
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.kg
+    ports:
+      - "8888:8888" # for testing direct access to the kernel gateway from outside docker
     image: jupyter/kernel-gateway
     environment:
       KG_ALLOW_ORIGIN: '*'
@@ -27,8 +29,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.client
-    image: jupyter/kernel-gateway-demo-client
     environment:
-      GATEWAY_URL: http://nginx
+      BASE_GATEWAY_HTTP_URL: http://nginx/jupyter/v1/12345678-1234-1234-1234-123456789012
+      # see https://github.com/jupyter/jupyter-js-services/issues/158 about username/password here
+      BASE_GATEWAY_WS_URL: ws://fakeuser:fakepass@nginx/jupyter/v1/12345678-1234-1234-1234-123456789012
     depends_on:
       - nginx

--- a/node_client_example/fake_htpasswd
+++ b/node_client_example/fake_htpasswd
@@ -1,0 +1,3 @@
+# generated with htpasswd util, fakeuser:fakepass
+# USE ONLY AS AN EXAMPLE!
+fakeuser:$apr1$4ZhnDsjP$YTj6gcQqyf0i4BMW4u028/

--- a/node_client_example/nginx.conf
+++ b/node_client_example/nginx.conf
@@ -23,8 +23,11 @@ http {
     listen                          80;
     server_name                     kernel_gateway;
 
-    location / {
-      proxy_pass http://kernel_gateway;
+    location /jupyter/v1/12345678-1234-1234-1234-123456789012/ {
+      auth_basic           "Kernel gateway auth";
+      auth_basic_user_file /etc/nginx/htpasswd;
+      
+      proxy_pass http://kernel_gateway/;
 
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;

--- a/node_client_example/src/client.js
+++ b/node_client_example/src/client.js
@@ -8,7 +8,9 @@ global.XMLHttpRequest = xmlhttprequest.XMLHttpRequest;
 global.WebSocket = ws;
 var jupyter = require('jupyter-js-services');
 
-var gatewayUrl = process.env.GATEWAY_URL || 'http://192.168.99.100:8888';
+var gatewayUrl = process.env.BASE_GATEWAY_HTTP_URL || 'http://localhost:8888';
+var gatewayWsUrl = process.env.BASE_GATEWAY_WS_URL || 'ws://localhost:8888';
+
 var demoLang = process.env.DEMO_LANG || 'python';
 var demoInfo = {
     python: {
@@ -29,8 +31,13 @@ var demoSrc = fs.readFileSync(demoInfo.filename, {encoding: 'utf-8'});
 console.log('Targeting server:', gatewayUrl);
 console.log('Using example code:', demoInfo.filename);
 
-// extra headers to demo that it can be done
 var ajaxSettings = {
+    // Basic auth params are OK (hardcoding these for the demo nginx proxy)
+    // but they only apply to the HTTP requests made by jupuyter-js-services
+    // at the moment. https://github.com/jupyter/jupyter-js-services/issues/158
+    user: 'fakeuser',
+    password: 'fakepass',
+    // extra headers are OK
     requestHeaders: {
         'X-Some-Header': 'some-value'
     }
@@ -47,6 +54,7 @@ jupyter.getKernelSpecs({
     console.log('Starting kernel:', demoLang)
     jupyter.startNewKernel({
         baseUrl: gatewayUrl,
+        wsUrl: gatewayWsUrl, // passing this separately to demonstrate basic auth
         name: demoInfo.kernelName,
         ajaxSettings: ajaxSettings
     }).then((kernel) => {

--- a/python_client_example/Dockerfile.client
+++ b/python_client_example/Dockerfile.client
@@ -1,15 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM python:3.5.1
+FROM python:3.5.1-alpine
 
-# make the default assume we're in the docker-compose setup where the 
-# nginx service is available on the default docker network
-ENV GATEWAY_HOST nginx:80
 WORKDIR /src
 RUN pip install tornado
-
 COPY src/* /src/
-
-
-
 ENTRYPOINT ["python", "/src/client.py"]

--- a/python_client_example/Dockerfile.nginx
+++ b/python_client_example/Dockerfile.nginx
@@ -3,3 +3,4 @@
 
 FROM nginx:1.7.6
 ADD nginx.conf /etc/nginx/nginx.conf
+ADD fake_htpasswd /etc/nginx/htpasswd

--- a/python_client_example/docker-compose.yml
+++ b/python_client_example/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: Dockerfile.nginx
     image: jupyter/kernel-gateway-nginx
     ports:
-      - "8080:80"
+      - "8080:80" # for testing proxied access to the kernel gateway from outside docker
     depends_on:
       - kernel_gateway
 
@@ -20,6 +20,8 @@ services:
       context: .
       dockerfile: Dockerfile.kg
     image: jupyter/kernel-gateway
+    ports:
+      - "8888:8888" # for testing direct access to the kernel gateway from outside docker
     environment:
       KG_ALLOW_ORIGIN: '*'
 
@@ -27,6 +29,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.client
-    image: jupyter/kernel-gateway-advanced-python-demo-client
+    environment:
+      BASE_GATEWAY_HTTP_URL: http://nginx/jupyter/v1/12345678-1234-1234-1234-123456789012
+      BASE_GATEWAY_WS_URL: ws://nginx/jupyter/v1/12345678-1234-1234-1234-123456789012
     depends_on:
       - nginx

--- a/python_client_example/fake_htpasswd
+++ b/python_client_example/fake_htpasswd
@@ -1,0 +1,3 @@
+# generated with htpasswd util, fakeuser:fakepass
+# USE ONLY AS AN EXAMPLE!
+fakeuser:$apr1$4ZhnDsjP$YTj6gcQqyf0i4BMW4u028/

--- a/python_client_example/nginx.conf
+++ b/python_client_example/nginx.conf
@@ -23,8 +23,11 @@ http {
     listen                          80;
     server_name                     kernel_gateway;
 
-    location / {
-      proxy_pass http://kernel_gateway;
+    location /jupyter/v1/12345678-1234-1234-1234-123456789012/ {
+      auth_basic           "Kernel gateway auth";
+      auth_basic_user_file /etc/nginx/htpasswd;
+      
+      proxy_pass http://kernel_gateway/;
 
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Demonstrate how clients can work with nginx proxy
that requires basic auth and has a custom base URL
for the API
