### PR TITLE
Bump notebook and kg versions.

### DIFF
--- a/nb2kg/Dockerfile.kg
+++ b/nb2kg/Dockerfile.kg
@@ -1,9 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/minimal-notebook:8015c88c4b11
+FROM jupyter/minimal-notebook:fa77fe99579b
 
-RUN pip install jupyter_kernel_gateway==0.5.1
+RUN pip install jupyter_kernel_gateway==1.1.2
 
 # run kernel gateway, not notebook server
 CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0"]

--- a/nb2kg/Dockerfile.notebook
+++ b/nb2kg/Dockerfile.notebook
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/minimal-notebook:8015c88c4b11
+FROM jupyter/minimal-notebook:fa77fe99579b
 
 # Do the pip installs as the unprivileged notebook user
 USER jovyan


### PR DESCRIPTION
In Docker example.  Necessary after #39.