### PR TITLE
Pass "KERNEL_*" env variables to kernels endpoint

### DIFF
--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -111,7 +111,10 @@ class RemoteKernelManager(MappingKernelManager):
             response = yield fetch_kg(
                 self.kernels_endpoint,
                 method='POST',
-                body=json_encode({'name' : kernel_name})
+                body=json_encode({
+                    'name': kernel_name,
+                    'env': {k:v for (k,v) in dict(os.environ).items() if k.startswith('KERNEL_')}
+                })
             )
             kernel = json_decode(response.body)
             kernel_id = kernel['id']


### PR DESCRIPTION
To enable this feature in **Jupyter Kernel Gateway**:

[Pass environment metadata to kernels on POST /api/kernels #128](https://github.com/jupyter/kernel_gateway/issues/128)