### PR TITLE
shutdown_all does not check VALIDATE_KG_CERT

### DIFF
--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -241,6 +241,7 @@ class RemoteKernelManager(MappingKernelManager):
             try:
                 response = client.fetch(kernel_url, 
                     headers=KG_HEADERS,
+                    validate_cert=VALIDATE_KG_CERT,                    
                     method='DELETE'
                 )
             except HTTPError:


### PR DESCRIPTION
When shutting down a notebook after shutdown_all has been called, the following is thrown:
[W 12:31:06.868 NotebookApp] SSL Error on 10 ('x.x.x.x', 8443): [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:765)

This adds the same validate_cert logic to shutdown_all which is used for fetch_kg