### PR TITLE
Pass env vars in "KG_WHITELIST" to kernel endpoint

### DIFF
--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -113,7 +113,7 @@ class RemoteKernelManager(MappingKernelManager):
                 method='POST',
                 body=json_encode({
                     'name': kernel_name,
-                    'env': {k:v for (k,v) in dict(os.environ).items() if k.startswith('KERNEL_')}
+                    'env': {k:v for (k,v) in dict(os.environ).items() if k.startswith('KERNEL_') or k in os.environ['KG_WHITELIST'].split(":")}
                 })
             )
             kernel = json_decode(response.body)

--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -113,7 +113,7 @@ class RemoteKernelManager(MappingKernelManager):
                 method='POST',
                 body=json_encode({
                     'name': kernel_name,
-                    'env': {k:v for (k,v) in dict(os.environ).items() if k.startswith('KERNEL_') or k in os.environ['KG_WHITELIST'].split(":")}
+                    'env': {k:v for (k,v) in dict(os.environ).items() if k.startswith('KERNEL_') or k in os.environ['KG_ENV_WHITELIST'].split(",")}
                 })
             )
             kernel = json_decode(response.body)


### PR DESCRIPTION
This feature is designed to be paired with Jupyter Kernel Gateways env_whitelist option.
"--JupyterWebsocketPersonality.env_whitelist=<List>
    Default: []
    Environment variables allowed to be set when a client requests a new kernel"

To use this feature, simply add the env var names into "KG_WHITELIST" using a colon delimited list.

example:
export KG_WHITELIST=SPARK_OPTS:SPARK_USER