### PR TITLE
Allow http user and password to be passed in if JKG is behind a secured gateway such as Apache Knox

### DIFF
--- a/nb2kg/nb2kg/handlers.py
+++ b/nb2kg/nb2kg/handlers.py
@@ -27,7 +27,8 @@ KG_HEADERS.update({
     'Authorization': 'token {}'.format(os.getenv('KG_AUTH_TOKEN', ''))
 })
 VALIDATE_KG_CERT = os.getenv('VALIDATE_KG_CERT') not in ['no', 'false']
-
+KG_HTTP_USER = os.getenv('KG_HTTP_USER', '')
+KG_HTTP_PASS = os.getenv('KG_HTTP_PASS', '')
 
 class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
 
@@ -108,7 +109,7 @@ class KernelGatewayWSClient(LoggingConfigurable):
             'channels'
         )
         self.log.info('Connecting to {}'.format(ws_url))
-        request = HTTPRequest(ws_url, headers=KG_HEADERS, validate_cert=VALIDATE_KG_CERT)
+        request = HTTPRequest(ws_url, headers=KG_HEADERS, validate_cert=VALIDATE_KG_CERT, auth_username=KG_HTTP_USER, auth_password=KG_HTTP_PASS)
         self.ws_future = websocket_connect(request)
         self.ws = yield self.ws_future
         # TODO: handle connection errors/timeout

--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -25,13 +25,15 @@ KG_HEADERS.update({
     'Authorization': 'token {}'.format(os.getenv('KG_AUTH_TOKEN', ''))
 })
 VALIDATE_KG_CERT = os.getenv('VALIDATE_KG_CERT') not in ['no', 'false']
+KG_HTTP_USER = os.getenv('KG_HTTP_USER', '')
+KG_HTTP_PASS = os.getenv('KG_HTTP_PASS', '')
 
 @gen.coroutine
 def fetch_kg(endpoint, **kwargs):
     """Make an async request to kernel gateway endpoint."""
     client = AsyncHTTPClient()
     url = url_path_join(KG_URL, endpoint)
-    response = yield client.fetch(url, headers=KG_HEADERS, validate_cert=VALIDATE_KG_CERT, **kwargs)
+    response = yield client.fetch(url, headers=KG_HEADERS, validate_cert=VALIDATE_KG_CERT, auth_username=KG_HTTP_USER, auth_password=KG_HTTP_PASS, **kwargs)
     raise gen.Return(response)
 
 


### PR DESCRIPTION
If Jupyter Kernel Gateway is behind a secured gateway which supports http and websocket traffic such as Apache Knox, we need to be able to pass in an `http_username` and `http_password`.

See https://issues.apache.org/jira/browse/KNOX-976

As this could also be used for other user/password based gateway auth, proposing adding in 2 new exports, `KG_HTTP_USER` and `KG_HTTP_PASS`