### PR TITLE
Implement NB2KG timeout check

### DIFF
--- a/nb2kg/Dockerfile.notebook
+++ b/nb2kg/Dockerfile.notebook
@@ -6,6 +6,9 @@ FROM jupyter/minimal-notebook:fa77fe99579b
 # Do the pip installs as the unprivileged notebook user
 USER jovyan
 
+# Upgrade pip
+RUN pip install --upgrade pip
+
 # Install dashboard layout and preview within Jupyter Notebook
 ADD . /src
 RUN pip install /src && \

--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -216,12 +216,8 @@ class RemoteKernelManager(MappingKernelManager):
         self.log.info("Request restart kernel: %s", kernel_id)
         kernel_url = self._kernel_id_to_url(kernel_id) + '/restart'
         self.log.info("Request restart kernel at: %s", kernel_url)
-        # Here 10 is used as the multiplier to increase the request timeout limit for kernel restart.
-        response = yield fetch_kg(kernel_url, method='POST',
-                                  request_timeout=float(KG_REQUEST_TIMEOUT) * 10,
-                                  body=json_encode({}))
-        self.log.info("Restart kernel response: %d %s",
-            response.code, response.reason)
+        response = yield fetch_kg(kernel_url, method='POST', body=json_encode({}))
+        self.log.info("Restart kernel response: %d %s", response.code, response.reason)
 
     @gen.coroutine
     def interrupt_kernel(self, kernel_id, **kwargs):
@@ -235,10 +231,7 @@ class RemoteKernelManager(MappingKernelManager):
         self.log.info("Request interrupt kernel: %s", kernel_id)
         kernel_url = self._kernel_id_to_url(kernel_id) + '/interrupt'
         self.log.info("Request interrupt kernel at: %s", kernel_url)
-        # Here 10 is used as the multiplier to increase the request timeout limit for kernel interrupt.
-        response = yield fetch_kg(kernel_url, method='POST',
-                                  request_timeout=float(KG_REQUEST_TIMEOUT) * 10,
-                                  body=json_encode({}))
+        response = yield fetch_kg(kernel_url, method='POST', body=json_encode({}))
         self.log.info("Interrupt kernel response: %d %s", response.code, response.reason)
 
     def shutdown_all(self):

--- a/nb2kg/nb2kg/managers.py
+++ b/nb2kg/nb2kg/managers.py
@@ -117,7 +117,6 @@ class RemoteKernelManager(MappingKernelManager):
         if kernel_id is None:
             kernel_name = kwargs.get('kernel_name', 'python3')
             self.log.info("Request new kernel at: %s" % self.kernels_endpoint)
-            # try
             kernel_env = {k: v for (k, v) in dict(os.environ).items() if k.startswith('KERNEL_')
                         or k in os.environ.get('KG_ENV_WHITELIST', '').split(",")}
             json_body = json_encode({'name': kernel_name, 'env': kernel_env})


### PR DESCRIPTION
Related to issue #54 

The default value of the 2 env variables `KG_CONNECT_TIMEOUT` and `KG_REQUEST_TIMEOUT` is 20.0, i.e. same as the `tornodo.httpclient.HTTPRequest`.

Some other minor changes:
1. remove packages not used
2. access the KG_ENV_WHITELIST by using `get` method
3. add upgrade pip to dockerfile.notebook (thanks to  @kevin-bates)

