### PR TITLE
 Support having different WS and HTTP urls

### DIFF
--- a/nb2kg/nb2kg/handlers.py
+++ b/nb2kg/nb2kg/handlers.py
@@ -112,7 +112,7 @@ class KernelGatewayWSClient(LoggingConfigurable):
     @gen.coroutine
     def _connect(self, kernel_id):
         ws_url = url_path_join(
-            KG_URL.replace('http', 'ws'), 
+            os.getenv('KG_WS_URL', KG_URL.replace('http', 'ws')),
             '/api/kernels', 
             url_escape(kernel_id),
             'channels'


### PR DESCRIPTION
nb2kg does not work when connecting to a host that has different urls for WS and HTTP, for example:

- wss://myhost:8443/gateway/default/jkgws/
- https://myhost:8443/gateway/default/jkg/

This patch allows users to specify the KG_WS_URL.