### PR TITLE
Add support for tornado versions >= 4.5 and allow Notebook > 5.0

### DIFF
--- a/nb2kg/.gitignore
+++ b/nb2kg/.gitignore
@@ -63,3 +63,6 @@ __pycache__/
 etc/notebooks/*
 .DS_Store
 .ipynb_checkpoints/
+
+IDE stuff
+.idea/

--- a/nb2kg/setup.py
+++ b/nb2kg/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(HERE, 'nb2kg', '_version.py')) as f:
     exec(f.read(), {}, VERSION_NS)
 
 install_requires=[
-    'notebook>=4.2.0,<5.0',
+    'notebook>=4.2.0,<6.0',
 ]
 
 setup_args = dict(


### PR DESCRIPTION
In tornado 4.5.0, the means of managing handlers was dramatically
adjusted for [PR #1806](https://github.com/tornadoweb/tornado/pull/1806).

With this change, the list of handlers that NB2KG's load needs to modify
was essentially relocated within the web application structure.  As a
result, attempts to load NB2KG on tornado versions >= 4.5 resulted in
a missing 'handlers' attribute exception - regardless of the Notebook
version.  This PR checks if the handlers attribute is present on the
web application structure and, if not, uses the new location (a list of
Rule instances) instead.  The rest of the load proceeds as before
thanks to the fact that the URLSpec class was modified to derive from
Rule - thereby maintaining the list's type constraint.

I've also gone ahead and moved the Notebook version cap from 5.0 to 6.0
since this was causing conflicts when attempting to install NB2KG and
Enterprise Gateway (which requires Notebook 5.1+) in the same env.

Fixes #56