### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/all-spark-kernels/Dockerfile
+++ b/all-spark-kernels/Dockerfile
@@ -6,7 +6,7 @@ FROM jupyter/all-spark-notebook:97a5071c5775
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 # Install Kernel Gateway
-RUN pip install 'jupyter_kernel_gateway>=1.0,<2.0'
+RUN pip install --no-cache-dir jupyter_kernel_gateway
 
 # Configure container startup, letting the user pass command line args through
 # easily without disrupting the use of tini or the kernelgateway entry point

--- a/microservice_demo/Dockerfile
+++ b/microservice_demo/Dockerfile
@@ -4,7 +4,7 @@ FROM jupyter/datascience-notebook
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 # Install Kernel Gateway
-RUN pip install jupyter-kernel-gateway
+RUN pip install --no-cache-dir jupyter-kernel-gateway
 
 # Configure container startup
 ENTRYPOINT ["tini", "--", "jupyter", "kernelgateway", "--KernelGatewayApp.api=notebook-http", "--KernelGatewayApp.ip=0.0.0.0", "--KernelGatewayApp.seed_uri=/srv/notebooks/meetup_service.ipynb"]

--- a/node_client_example/Dockerfile.kg
+++ b/node_client_example/Dockerfile.kg
@@ -5,7 +5,7 @@
 FROM jupyter/all-spark-notebook:0017b56d93c9
 
 # install the kernel gateway
-RUN pip install jupyter_kernel_gateway==0.5.*
+RUN pip install --no-cache-dir jupyter_kernel_gateway
 
 # run kernel gateway on container start, not notebook server
 EXPOSE 8888

--- a/python_client_example/Dockerfile.client
+++ b/python_client_example/Dockerfile.client
@@ -3,6 +3,6 @@
 FROM python:latest
 
 WORKDIR /src
-RUN pip install tornado
+RUN pip install --no-cache-dir tornado
 COPY src/* /src/
 ENTRYPOINT ["python", "/src/client.py"]

--- a/python_client_example/Dockerfile.kg
+++ b/python_client_example/Dockerfile.kg
@@ -5,7 +5,7 @@
 FROM jupyter/all-spark-notebook:0017b56d93c9
 
 # install the kernel gateway
-RUN pip install 'jupyter_kernel_gateway==0.5'
+RUN pip install --no-cache-dir jupyter_kernel_gateway
 
 # run kernel gateway on container start, not notebook server
 EXPOSE 8888

--- a/scotch_demo/Dockerfile
+++ b/scotch_demo/Dockerfile
@@ -4,4 +4,4 @@ FROM jupyter/datascience-notebook:8015c88c4b11
 RUN julia -e 'Pkg.add("JSON")' && julia -e 'Pkg.add("Requests")'
 
 # Install latest stable Kernel Gateway
-RUN pip install jupyter_kernel_gateway
+RUN pip install --no-cache-dir jupyter_kernel_gateway

--- a/swagger-notebook-service/jupyter-swagger-codegen/src/main/resources/jupyter-swagger-codegen/Dockerfile.mustache
+++ b/swagger-notebook-service/jupyter-swagger-codegen/src/main/resources/jupyter-swagger-codegen/Dockerfile.mustache
@@ -3,7 +3,7 @@
 FROM jupyter/all-spark-notebook:dbb9c7b50531
 
 # Install Kernel Gateway
-RUN pip install git+https://github.com/jupyter-incubator/kernel_gateway.git
+RUN pip install --no-cache-dir jupyter_kernel_gateway
 
 # Configure container startup
 ENTRYPOINT ["tini", "--", "jupyter", "kernelgateway"]

--- a/swagger-notebook-service/swagger-petstore-service/Dockerfile
+++ b/swagger-notebook-service/swagger-petstore-service/Dockerfile
@@ -3,7 +3,7 @@
 FROM jupyter/all-spark-notebook:dbb9c7b50531
 
 # Install Kernel Gateway
-RUN pip install git+https://github.com/jupyter-incubator/kernel_gateway.git
+RUN pip install --no-cache-dir jupyter_kernel_gateway
 
 # Configure container startup
 ENTRYPOINT ["tini", "--", "jupyter", "kernelgateway"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6