### PR TITLE
Changed tag for all-spark-notebook image to 'latest'

### DIFF
--- a/python_client_example/Dockerfile.kg
+++ b/python_client_example/Dockerfile.kg
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 # start from the jupyter image with R, Python, and Scala (Apache Toree) kernels pre-installed
-FROM jupyter/all-spark-notebook:0017b56d93c9
+FROM jupyter/all-spark-notebook:latest
 
 # install the kernel gateway
 RUN pip install --no-cache-dir jupyter_kernel_gateway


### PR DESCRIPTION
Fix for python_client_example build fails #71 